### PR TITLE
specs won't run on ruby1.8

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
 
 # Prefer to load from ../lib before the system paths.
-$:.unshift File.absolute_path(File.join(File.dirname(__FILE__),"..","lib"))
+$:.unshift File.expand_path(File.join(File.dirname(__FILE__),"..","lib"))


### PR DESCRIPTION
ruby 1.8 does not have the File.absolute_path method, but I believe the File.expand_path method works just as well in this case and is available in both ruby 1.8 and 1.9
